### PR TITLE
Updated runcromw.sh

### DIFF
--- a/hydrant/bin/runcromw.sh
+++ b/hydrant/bin/runcromw.sh
@@ -8,7 +8,7 @@
 #       . automatically finds and displays the contents of stderr 
 #       . creates soft link to the execution directory, called latest
 #
-# Assumes color terminal (error content is bracked by RED control sequences)
+# Assumes color terminal (error content is bracketed by RED control sequences)
 
 set -o pipefail
 
@@ -44,8 +44,8 @@ chkfile $PathToWDL
 chkfile $PathToInputs
 chkfile $Options
 
-TaskNames=(`awk '/^[[:space:]]*task/ {print $2}' $PathToWDL`)
-FlowName=`awk '/^[[:space:]]*workflow/ {print $2; exit}' $PathToWDL`
+TaskNames=(`awk '/^[ 	]*task/ {print $2}' $PathToWDL`)
+FlowName=`awk '/^[ 	]*workflow/ {print $2; exit}' $PathToWDL`
 ExecDir=running
 DoneDir=latest
 LogFile=run-${FlowName}.`date +"%Y_%m_%d__%H_%M_%S"`.log


### PR DESCRIPTION
@chipstewart reports that running `hydrant test` consistently gives the following error for him:
`awk: line 13: illegal reference to array TaskNameAry`

On investigation, it turns out that debian linux distributions default to using an older version of `mawk` for `awk` (rather than `gawk`) that doesn't handle character classes.

Awk calls have been updated to not use character classes, thus improving portability.